### PR TITLE
Initial changes for SICL

### DIFF
--- a/Code/cyclosis-intrinsic.asd
+++ b/Code/cyclosis-intrinsic.asd
@@ -1,6 +1,7 @@
 (cl:in-package #:asdf-user)
 
 (defsystem #:cyclosis-intrinsic
+  :depends-on (#:alexandria)
   :serial t
   :components
   ((:file "packages-intrinsic")

--- a/Code/cyclosis.asd
+++ b/Code/cyclosis.asd
@@ -1,6 +1,7 @@
 (cl:in-package #:asdf-user)
 
 (defsystem #:cyclosis
+  :depends-on (#:alexandria)
   :serial t
   :components
   ((:file "packages")

--- a/Code/gray-streams.lisp
+++ b/Code/gray-streams.lisp
@@ -80,9 +80,22 @@
 (defgeneric stream-terpri (stream))
 (defgeneric stream-write-char (stream character))
 (defgeneric stream-write-string (stream string &optional start end))
+(defgeneric streamp (stream))
+
+;;; Generic functions for Gray Stream extensions
+
 (defgeneric stream-display (stream object))
+(defgeneric stream-peek-char-skip-whitespace (stream))
 
 ;;; Default Gray methods
+
+(defmethod streamp (stream)
+  (declare (ignore stream))
+  nil)
+
+(defmethod streamp ((stream stream))
+  (declare (ignore stream))
+  t)
 
 (defmethod stream-display (stream (object fundamental-character-output-stream))
   (format stream "~S" object))
@@ -200,6 +213,12 @@
     (cond ((eql ch :eof) :eof)
           (t (unread-char ch stream)
              ch))))
+
+(defmethod stream-peek-char-skip-whitespace ((stream fundamental-character-input-stream))
+  (loop for ch = (stream-peek-char stream)
+        while (equal ch #\Space)
+        do (stream-read-char stream)
+        finally (return ch)))
 
 (defmethod stream-read-char-no-hang ((stream fundamental-character-input-stream))
   (read-char stream nil :eof))

--- a/Code/packages-intrinsic.lisp
+++ b/Code/packages-intrinsic.lisp
@@ -29,6 +29,10 @@
    #:fundamental-binary-output-stream
    #:fundamental-character-input-stream
    #:fundamental-character-output-stream
+   ;; Utility Streams
+   #:binary-output-stream
+   #:binary-output-stream-buffer
+   #:binary-output-stream-element-type
    ;; CL Stream functions
    #:input-stream-p
    #:output-stream-p
@@ -126,5 +130,6 @@
    ;; Extensions.
    #:unread-char-mixin
    #:stream-display
+   #:stream-peek-char-skip-whitespace
    #:stream-open-p
    #:external-format-string-length))

--- a/Code/packages.lisp
+++ b/Code/packages.lisp
@@ -29,6 +29,10 @@
    #:fundamental-binary-output-stream
    #:fundamental-character-input-stream
    #:fundamental-character-output-stream
+   ;; Utility Streams
+   #:binary-output-stream
+   #:binary-output-stream-buffer
+   #:binary-output-stream-element-type
    ;; CL Stream functions
    #:input-stream-p
    #:output-stream-p
@@ -126,6 +130,7 @@
    ;; Extensions.
    #:unread-char-mixin
    #:stream-display
+   #:stream-peek-char-skip-whitespace
    #:stream-open-p
    #:external-format-string-length)
   (:export

--- a/Code/standard-streams.lisp
+++ b/Code/standard-streams.lisp
@@ -598,16 +598,12 @@
            0))))
 
 (defmacro with-output-to-string ((var &optional string-form &key (element-type ''character)) &body body)
-  (multiple-value-bind (real-body declares)
-      (parse-declares body)
-    (if string-form
-        `(with-open-stream (,var (make-string-output-stream :string ,string-form :element-type ,element-type))
-           (declare ,@declares)
-           ,@real-body)
-        `(with-open-stream (,var (make-string-output-stream :element-type ,element-type))
-           (declare ,@declares)
-           ,@real-body
-           (get-output-stream-string ,var)))))
+  (if string-form
+      `(with-open-stream (,var (make-string-output-stream :string ,string-form :element-type ,element-type))
+         ,@body)
+      `(with-open-stream (,var (make-string-output-stream :element-type ,element-type))
+         ,@body
+         (get-output-stream-string ,var))))
 
 ;;; String input stream and with-input-from-string.
 
@@ -646,9 +642,9 @@
 (defmacro with-input-from-string ((var string &key (start 0) end index) &body body)
   (cond (index
          (multiple-value-bind (body-forms declares)
-             (parse-declares body)
+             (alexandria:parse-body body)
            `(with-open-stream (,var (make-string-input-stream ,string ,start ,end))
-              (declare ,@declares)
+              ,@declares
               (multiple-value-prog1
                   (progn ,@body-forms)
                 (setf ,index (string-input-stream-position ,var))))))


### PR DESCRIPTION
This PR removes the tracking stream code which dependent on Mezzano code in `read` and "comments" out the cold stream code since this is mostly Mezzano specific (at least for now). The initialization code for the `*standard-output*` is in the corresponding SICL PR.

Fix some other typos and errors also.