### PR TITLE
Cleanup code a bit

### DIFF
--- a/Code/gray-streams.lisp
+++ b/Code/gray-streams.lisp
@@ -20,21 +20,13 @@
   ()
   (:documentation "A superclass of all Gray output streams."))
 
-(defclass fundamental-binary-stream (fundamental-stream)
-  ()
-  (:documentation "A superclass of all Gray streams whose element-type is a subtype of unsigned-byte or signed-byte."))
-
 (defclass fundamental-character-stream (fundamental-stream)
   ()
   (:documentation "A superclass of all Gray streams whose element-type is a subtype of character."))
 
-(defclass fundamental-binary-input-stream (fundamental-input-stream fundamental-binary-stream)
+(defclass fundamental-binary-stream (fundamental-stream)
   ()
-  (:documentation "A superclass of all Gray input streams whose element-type is a subtype of unsigned-byte or signed-byte."))
-
-(defclass fundamental-binary-output-stream (fundamental-output-stream fundamental-binary-stream)
-  ()
-  (:documentation "A superclass of all Gray output streams whose element-type is a subtype of unsigned-byte or signed-byte."))
+  (:documentation "A superclass of all Gray streams whose element-type is a subtype of unsigned-byte or signed-byte."))
 
 (defclass fundamental-character-input-stream (fundamental-input-stream fundamental-character-stream)
   ()
@@ -44,47 +36,100 @@
   ()
   (:documentation "A superclass of all Gray output streams whose element-type is a subtype of character."))
 
-;;; Generic functions for Gray Streams.
+(defclass fundamental-binary-input-stream (fundamental-input-stream fundamental-binary-stream)
+  ()
+  (:documentation "A superclass of all Gray input streams whose element-type is a subtype of unsigned-byte or signed-byte."))
 
-(defgeneric stream-element-type (stream))
-(defgeneric stream-external-format (stream))
-(defgeneric close (stream &key abort))
-(defgeneric open-stream-p (stream))
-(defgeneric input-stream-p (stream))
-(defgeneric output-stream-p (stream))
-(defgeneric interactive-stream-p (stream))
-(defgeneric stream-file-position (stream &optional position-spec))
-(defgeneric stream-file-length (stream))
-(defgeneric stream-file-string-length (stream string))
-(defgeneric stream-clear-input (stream))
-(defgeneric stream-read-sequence (stream seq &optional start end))
-(defgeneric stream-clear-output (stream))
-(defgeneric stream-finish-output (stream))
-(defgeneric stream-force-output (stream))
-(defgeneric stream-write-sequence (stream seq &optional start end))
-(defgeneric stream-read-byte (stream))
-(defgeneric stream-read-byte-no-hang (stream))
-(defgeneric stream-write-byte (stream integer))
-(defgeneric stream-listen-byte (stream))
-(defgeneric stream-peek-char (stream))
-(defgeneric stream-read-char-no-hang (stream))
+(defclass fundamental-binary-output-stream (fundamental-output-stream fundamental-binary-stream)
+  ()
+  (:documentation "A superclass of all Gray output streams whose element-type is a subtype of unsigned-byte or signed-byte."))
+
+;;; Character input
+
 (defgeneric stream-read-char (stream))
-(defgeneric stream-read-line (stream))
-(defgeneric stream-listen (stream))
+
 (defgeneric stream-unread-char (stream character))
-(defgeneric stream-advance-to-column (stream column))
-(defgeneric stream-fresh-line (stream))
-(defgeneric stream-line-column (stream))
-(defgeneric stream-line-length (stream))
-(defgeneric stream-start-line-p (stream))
-(defgeneric stream-terpri (stream))
+
+(defgeneric stream-read-char-no-hang (stream))
+
+(defgeneric stream-peek-char (stream))
+
+(defgeneric stream-listen (stream))
+
+(defgeneric stream-read-line (stream))
+
+(defgeneric stream-clear-input (stream))
+
+;;; Character output
+
 (defgeneric stream-write-char (stream character))
+
+(defgeneric stream-line-column (stream))
+
+(defgeneric stream-start-line-p (stream))
+
 (defgeneric stream-write-string (stream string &optional start end))
+
+(defgeneric stream-terpri (stream))
+
+(defgeneric stream-fresh-line (stream))
+
+(defgeneric stream-finish-output (stream))
+
+(defgeneric stream-force-output (stream))
+
+(defgeneric stream-clear-output (stream))
+
+(defgeneric stream-advance-to-column (stream column))
+
+;;; Other functions
+
+(defgeneric close (stream &key abort))
+
+(defgeneric open-stream-p (stream))
+
 (defgeneric streamp (stream))
 
-;;; Generic functions for Gray Stream extensions
+(defgeneric input-stream-p (stream))
 
-(defgeneric stream-display (stream object))
+(defgeneric output-stream-p (stream))
+
+(defgeneric stream-element-type (stream))
+
+;;; Binary streams
+
+(defgeneric stream-read-byte (stream))
+
+(defgeneric stream-write-byte (stream integer))
+
+;;; Extensions to Gray Streams
+
+;;; Common Lisp functions made generic
+
+(defgeneric stream-external-format (stream))
+
+(defgeneric interactive-stream-p (stream))
+
+;;; Generic support for other CL stream functions
+
+(defgeneric stream-file-position (stream &optional position-spec))
+
+(defgeneric stream-file-length (stream))
+
+(defgeneric stream-file-string-length (stream string))
+
+(defgeneric stream-read-sequence (stream seq &optional start end))
+
+(defgeneric stream-write-sequence (stream seq &optional start end))
+
+;;; Generalization for byte streams and other extensions
+
+(defgeneric stream-read-byte-no-hang (stream))
+
+(defgeneric stream-listen-byte (stream))
+
+(defgeneric stream-line-length (stream))
+
 (defgeneric stream-peek-char-skip-whitespace (stream))
 
 ;;; Default Gray methods
@@ -96,9 +141,6 @@
 (defmethod streamp ((stream stream))
   (declare (ignore stream))
   t)
-
-(defmethod stream-display (stream (object fundamental-character-output-stream))
-  (format stream "~S" object))
 
 (defmethod stream-line-column ((stream fundamental-character-output-stream))
   nil)
@@ -151,25 +193,25 @@
   (error 'type-error :expected-type 'stream :datum stream))
 
 (defmethod input-stream-p ((stream fundamental-stream))
-  'nil)
+  nil)
 
 (defmethod input-stream-p ((stream fundamental-input-stream))
-  't)
+  t)
 
 (defmethod output-stream-p ((stream t))
   (error 'type-error :expected-type 'stream :datum stream))
 
 (defmethod output-stream-p ((stream fundamental-stream))
-  'nil)
+  nil)
 
 (defmethod output-stream-p ((stream fundamental-output-stream))
-  't)
+  t)
 
 (defmethod interactive-stream-p ((stream t))
   (error 'type-error :expected-type 'stream :datum stream))
 
 (defmethod interactive-stream-p ((stream fundamental-stream))
-  'nil)
+  nil)
 
 (defmethod stream-element-type ((stream fundamental-character-stream))
   'character)
@@ -262,7 +304,8 @@
   (write-char #\Newline stream))
 
 (defmethod stream-write-string ((stream fundamental-character-output-stream) string &optional (start 0) end)
-  (write-sequence string stream :start start :end end)
+  (loop for index from start below (or end (length string))
+        do (stream-write-char stream (char string index)))
   string)
 
 (defmethod stream-file-position ((stream fundamental-stream) &optional position-spec)

--- a/Code/packages-intrinsic.lisp
+++ b/Code/packages-intrinsic.lisp
@@ -3,23 +3,7 @@
 (defpackage #:cyclosis
   (:use #:common-lisp)
   (:export
-   #:*terminal-io*
-   #:*debug-io*
-   #:*error-output*
-   #:*query-io*
-   #:*standard-input*
-   #:*standard-output*
-   #:*trace-output*
-   ;; CL Streams classes.
-   #:stream
-   #:broadcast-stream
-   #:concatenated-stream
-   #:echo-stream
-   #:file-stream
-   #:string-stream
-   #:synonym-stream
-   #:two-way-stream
-   ;; Gray Streams classes.
+   ;;; Interface symbols
    #:fundamental-stream
    #:fundamental-input-stream
    #:fundamental-output-stream
@@ -29,96 +13,28 @@
    #:fundamental-binary-output-stream
    #:fundamental-character-input-stream
    #:fundamental-character-output-stream
-   ;; Utility Streams
    #:binary-output-stream
    #:binary-output-stream-buffer
    #:binary-output-stream-element-type
-   ;; CL Stream functions
-   #:input-stream-p
-   #:output-stream-p
-   #:interactive-stream-p
-   #:open-stream-p
-   #:stream-element-type
-   #:streamp
-   #:read-byte
-   #:write-byte
-   #:peek-char
-   #:read-char
-   #:read-char-no-hang
-   #:terpri
-   #:fresh-line
-   #:unread-char
-   #:write-char
-   #:read-line
-   #:write-string
-   #:write-line
-   #:read-sequence
-   #:write-sequence
-   #:file-length
-   #:file-position
-   #:file-string-length
-   #:open
-   #:stream-external-format
-   #:close
-   #:listen
-   #:clear-input
-   #:finish-output
-   #:force-output
-   #:clear-output
-   #:y-or-n-p
-   #:yes-or-no-p
-   #:make-synonym-stream
-   #:synonym-stream-symbol
-   #:broadcast-stream-streams
-   #:make-broadcast-stream
-   #:make-two-way-stream
-   #:two-way-stream-input-stream
-   #:two-way-stream-output-stream
-   #:echo-stream-input-stream
-   #:echo-stream-output-stream
-   #:make-echo-stream
-   #:concatenated-stream-streams
-   #:make-concatenated-stream
-   #:get-output-stream-string
-   #:make-string-input-stream
-   #:make-string-output-stream
-   #:stream-error-stream
-   #:with-open-file
-   #:with-open-stream
-   #:with-input-from-string
-   #:with-output-to-string
-   ;; Methods common to all streams.
-   #:stream-element-type
-   #:close
    #:stream-file-position
    #:stream-file-length
    #:stream-file-string-length
-   #:open-stream-p
-   #:input-stream-p
-   #:output-stream-p
-   #:interactive-stream-p
-   #:stream-external-format
-   ;; Input stream methods.
    #:stream-clear-input
    #:stream-read-sequence
-   ;; Output stream methods.
    #:stream-clear-output
    #:stream-finish-output
    #:stream-force-output
    #:stream-write-sequence
-   ;;; Binary stream methods.
    #:stream-read-byte
    #:stream-read-byte-no-hang
    #:stream-write-byte
    #:stream-listen-byte
-   ;;; Character input stream methods.
    #:stream-peek-char
    #:stream-read-char-no-hang
    #:stream-read-char
    #:stream-read-line
    #:stream-listen
    #:stream-unread-char
-   ;;; Character output stream methods.
    #:stream-advance-to-column
    #:stream-fresh-line
    #:stream-line-column
@@ -127,9 +43,7 @@
    #:stream-terpri
    #:stream-write-char
    #:stream-write-string
-   ;; Extensions.
    #:unread-char-mixin
-   #:stream-display
    #:stream-peek-char-skip-whitespace
    #:stream-open-p
    #:external-format-string-length))

--- a/Code/packages.lisp
+++ b/Code/packages.lisp
@@ -3,23 +3,129 @@
 (defpackage #:cyclosis
   (:use #:common-lisp)
   (:shadow
-   #:*terminal-io*
-   #:*debug-io*
-   #:*error-output*
-   #:*query-io*
-   #:*standard-input*
-   #:*standard-output*
-   #:*trace-output*
-   ;; CL Streams classes.
-   #:stream
    #:broadcast-stream
+   #:broadcast-stream-streams
+   #:clear-input
+   #:clear-output
+   #:close
    #:concatenated-stream
+   #:concatenated-stream-streams
    #:echo-stream
+   #:echo-stream-input-stream
+   #:echo-stream-output-stream
+   #:file-length
+   #:file-position
    #:file-stream
+   #:file-string-length
+   #:finish-output
+   #:force-output
+   #:fresh-line
+   #:get-output-stream-string
+   #:input-stream-p
+   #:interactive-stream-p
+   #:listen
+   #:make-broadcast-stream
+   #:make-concatenated-stream
+   #:make-echo-stream
+   #:make-string-input-stream
+   #:make-string-output-stream
+   #:make-synonym-stream
+   #:make-two-way-stream
+   #:open
+   #:open-stream-p
+   #:output-stream-p
+   #:peek-char
+   #:read-byte
+   #:read-char
+   #:read-char-no-hang
+   #:read-line
+   #:read-sequence
+   #:stream
+   #:stream-element-type
+   #:stream-external-format
+   #:streamp
    #:string-stream
    #:synonym-stream
+   #:synonym-stream-symbol
+   #:terpri
    #:two-way-stream
-   ;; Gray Streams classes.
+   #:two-way-stream-input-stream
+   #:two-way-stream-output-stream
+   #:unread-char
+   #:with-input-from-string
+   #:with-open-file
+   #:with-open-stream
+   #:with-output-to-string
+   #:write-byte
+   #:write-char
+   #:write-line
+   #:write-sequence
+   #:write-string
+   #:yes-or-no-p
+   #:y-or-n-p)
+  (:export
+   ;;; CL symbols
+   #:broadcast-stream
+   #:broadcast-stream-streams
+   #:clear-input
+   #:clear-output
+   #:close
+   #:concatenated-stream
+   #:concatenated-stream-streams
+   #:echo-stream
+   #:echo-stream-input-stream
+   #:echo-stream-output-stream
+   #:file-length
+   #:file-position
+   #:file-stream
+   #:file-string-length
+   #:finish-output
+   #:force-output
+   #:fresh-line
+   #:get-output-stream-string
+   #:input-stream-p
+   #:interactive-stream-p
+   #:listen
+   #:make-broadcast-stream
+   #:make-concatenated-stream
+   #:make-echo-stream
+   #:make-string-input-stream
+   #:make-string-output-stream
+   #:make-synonym-stream
+   #:make-two-way-stream
+   #:open
+   #:open-stream-p
+   #:output-stream-p
+   #:peek-char
+   #:read-byte
+   #:read-char
+   #:read-char-no-hang
+   #:read-line
+   #:read-sequence
+   #:stream
+   #:stream-element-type
+   #:stream-external-format
+   #:streamp
+   #:string-stream
+   #:synonym-stream
+   #:synonym-stream-symbol
+   #:terpri
+   #:two-way-stream
+   #:two-way-stream-input-stream
+   #:two-way-stream-output-stream
+   #:unread-char
+   #:with-input-from-string
+   #:with-open-file
+   #:with-open-stream
+   #:with-output-to-string
+   #:write-byte
+   #:write-char
+   #:write-line
+   #:write-sequence
+   #:write-string
+   #:yes-or-no-p
+   #:y-or-n-p
+   ;;; Interface symbols
    #:fundamental-stream
    #:fundamental-input-stream
    #:fundamental-output-stream
@@ -29,96 +135,28 @@
    #:fundamental-binary-output-stream
    #:fundamental-character-input-stream
    #:fundamental-character-output-stream
-   ;; Utility Streams
    #:binary-output-stream
    #:binary-output-stream-buffer
    #:binary-output-stream-element-type
-   ;; CL Stream functions
-   #:input-stream-p
-   #:output-stream-p
-   #:interactive-stream-p
-   #:open-stream-p
-   #:stream-element-type
-   #:streamp
-   #:read-byte
-   #:write-byte
-   #:peek-char
-   #:read-char
-   #:read-char-no-hang
-   #:terpri
-   #:fresh-line
-   #:unread-char
-   #:write-char
-   #:read-line
-   #:write-string
-   #:write-line
-   #:read-sequence
-   #:write-sequence
-   #:file-length
-   #:file-position
-   #:file-string-length
-   #:open
-   #:stream-external-format
-   #:close
-   #:listen
-   #:clear-input
-   #:finish-output
-   #:force-output
-   #:clear-output
-   #:y-or-n-p
-   #:yes-or-no-p
-   #:make-synonym-stream
-   #:synonym-stream-symbol
-   #:broadcast-stream-streams
-   #:make-broadcast-stream
-   #:make-two-way-stream
-   #:two-way-stream-input-stream
-   #:two-way-stream-output-stream
-   #:echo-stream-input-stream
-   #:echo-stream-output-stream
-   #:make-echo-stream
-   #:concatenated-stream-streams
-   #:make-concatenated-stream
-   #:get-output-stream-string
-   #:make-string-input-stream
-   #:make-string-output-stream
-   #:stream-error-stream
-   #:with-open-file
-   #:with-open-stream
-   #:with-input-from-string
-   #:with-output-to-string
-   ;; Methods common to all streams.
-   #:stream-element-type
-   #:close
    #:stream-file-position
    #:stream-file-length
    #:stream-file-string-length
-   #:open-stream-p
-   #:input-stream-p
-   #:output-stream-p
-   #:interactive-stream-p
-   #:stream-external-format
-   ;; Input stream methods.
    #:stream-clear-input
    #:stream-read-sequence
-   ;; Output stream methods.
    #:stream-clear-output
    #:stream-finish-output
    #:stream-force-output
    #:stream-write-sequence
-   ;;; Binary stream methods.
    #:stream-read-byte
    #:stream-read-byte-no-hang
    #:stream-write-byte
    #:stream-listen-byte
-   ;;; Character input stream methods.
    #:stream-peek-char
    #:stream-read-char-no-hang
    #:stream-read-char
    #:stream-read-line
    #:stream-listen
    #:stream-unread-char
-   ;;; Character output stream methods.
    #:stream-advance-to-column
    #:stream-fresh-line
    #:stream-line-column
@@ -127,135 +165,7 @@
    #:stream-terpri
    #:stream-write-char
    #:stream-write-string
-   ;; Extensions.
    #:unread-char-mixin
-   #:stream-display
    #:stream-peek-char-skip-whitespace
-   #:stream-open-p
-   #:external-format-string-length)
-  (:export
-   #:*terminal-io*
-   #:*debug-io*
-   #:*error-output*
-   #:*query-io*
-   #:*standard-input*
-   #:*standard-output*
-   #:*trace-output*
-   ;; CL Streams classes.
-   #:stream
-   #:broadcast-stream
-   #:concatenated-stream
-   #:echo-stream
-   #:file-stream
-   #:string-stream
-   #:synonym-stream
-   #:two-way-stream
-   ;; Gray Streams classes.
-   #:fundamental-stream
-   #:fundamental-input-stream
-   #:fundamental-output-stream
-   #:fundamental-binary-stream
-   #:fundamental-character-stream
-   #:fundamental-binary-input-stream
-   #:fundamental-binary-output-stream
-   #:fundamental-character-input-stream
-   #:fundamental-character-output-stream
-   ;; CL Stream functions
-   #:input-stream-p
-   #:output-stream-p
-   #:interactive-stream-p
-   #:open-stream-p
-   #:stream-element-type
-   #:streamp
-   #:read-byte
-   #:write-byte
-   #:peek-char
-   #:read-char
-   #:read-char-no-hang
-   #:terpri
-   #:fresh-line
-   #:unread-char
-   #:write-char
-   #:read-line
-   #:write-string
-   #:write-line
-   #:read-sequence
-   #:write-sequence
-   #:file-length
-   #:file-position
-   #:file-string-length
-   #:open
-   #:stream-external-format
-   #:close
-   #:listen
-   #:clear-input
-   #:finish-output
-   #:force-output
-   #:clear-output
-   #:y-or-n-p
-   #:yes-or-no-p
-   #:make-synonym-stream
-   #:synonym-stream-symbol
-   #:broadcast-stream-streams
-   #:make-broadcast-stream
-   #:make-two-way-stream
-   #:two-way-stream-input-stream
-   #:two-way-stream-output-stream
-   #:echo-stream-input-stream
-   #:echo-stream-output-stream
-   #:make-echo-stream
-   #:concatenated-stream-streams
-   #:make-concatenated-stream
-   #:get-output-stream-string
-   #:make-string-input-stream
-   #:make-string-output-stream
-   #:stream-error-stream
-   #:with-open-file
-   #:with-open-stream
-   #:with-input-from-string
-   #:with-output-to-string
-   ;; Methods common to all streams.
-   #:stream-element-type
-   #:close
-   #:stream-file-position
-   #:stream-file-length
-   #:stream-file-string-length
-   #:open-stream-p
-   #:input-stream-p
-   #:output-stream-p
-   #:interactive-stream-p
-   #:stream-external-format
-   ;; Input stream methods.
-   #:stream-clear-input
-   #:stream-read-sequence
-   ;; Output stream methods.
-   #:stream-clear-output
-   #:stream-finish-output
-   #:stream-force-output
-   #:stream-write-sequence
-   ;;; Binary stream methods.
-   #:stream-read-byte
-   #:stream-read-byte-no-hang
-   #:stream-write-byte
-   #:stream-listen-byte
-   ;;; Character input stream methods.
-   #:stream-peek-char
-   #:stream-read-char-no-hang
-   #:stream-read-char
-   #:stream-read-line
-   #:stream-listen
-   #:stream-unread-char
-   ;;; Character output stream methods.
-   #:stream-advance-to-column
-   #:stream-fresh-line
-   #:stream-line-column
-   #:stream-line-length
-   #:stream-start-line-p
-   #:stream-terpri
-   #:stream-write-char
-   #:stream-write-string
-   ;; Extensions.
-   #:unread-char-mixin
-   #:stream-display
    #:stream-open-p
    #:external-format-string-length))

--- a/Code/standard-streams.lisp
+++ b/Code/standard-streams.lisp
@@ -119,9 +119,6 @@
 (defmethod stream-write-string ((stream synonym-stream) string &optional (start 0) end)
   (write-string string (follow-synonym-stream stream) :start start :end end))
 
-(defmethod stream-display ((stream synonym-stream) object)
-  (stream-display (follow-synonym-stream stream) object))
-
 ;;; Broadcast stream.
 
 (defclass broadcast-stream (fundamental-output-stream)


### PR DESCRIPTION
- Rewrite the frob functions to use generics versus `typep`.
- Add `write-line` function.
- Reorganize package files and only shadow CL symbols.
- Remove `stream-display` generic.
- Remove cold stream stuff until a suitable generic interface
  can be made.

Also, I put Gray stream interface functions and classes in the same order as the spec to make it easy to compare the two. I left the stream-edit stuff in for now.